### PR TITLE
Use currentlanguage translation

### DIFF
--- a/src/Service/WmSingles.php
+++ b/src/Service/WmSingles.php
@@ -4,14 +4,12 @@ namespace Drupal\wmSingles\Service;
 
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Entity\Query\QueryInterface;
+use Drupal\Core\Language\LanguageManagerInterface;
 use Drupal\node\NodeInterface;
 use Drupal\node\NodeTypeInterface;
 use Drupal\node\Entity\NodeType;
 use Drupal\Core\State\StateInterface;
 
-/**
- * Provides common functionality for content translation.
- */
 class WmSingles
 {
 
@@ -30,17 +28,27 @@ class WmSingles
     protected $state;
 
     /**
+     * The language manager.
+     *
+     * @var \Drupal\Core\Language\LanguageManagerInterface
+     */
+    protected $languageManager;
+
+    /**
      * Constructs a WmContentManageAccessCheck object.
      *
      * @param EntityTypeManagerInterface $entityTypeManager
      * @param StateInterface $state
+     * @param LanguageManagerInterface $languageManager
      */
     public function __construct(
         EntityTypeManagerInterface $entityTypeManager,
-        StateInterface $state
+        StateInterface $state,
+        LanguageManagerInterface $languageManager
     ) {
         $this->entityTypeManager = $entityTypeManager;
         $this->state = $state;
+        $this->languageManager = $languageManager;
     }
 
     /**
@@ -86,9 +94,9 @@ class WmSingles
     public function getSingle(NodeTypeInterface $type)
     {
         if ($id = $this->getSnowFlake($type)) {
-            return $this->entityTypeManager->getStorage('node')->load($id);
+            return $this->loadNode($id);
         }
-        return false;
+        return null;
     }
 
     /**
@@ -154,5 +162,18 @@ class WmSingles
     private function getSnowFlakeKey(NodeTypeInterface $type)
     {
         return 'wmsingles.' . $type->id();
+    }
+
+    private function loadNode($id)
+    {
+        $langcode = $this->languageManager->getCurrentLanguage()->getId();
+        /** @var NodeInterface $single */
+        $single = $this->entityTypeManager->getStorage('node')->load($id);
+
+        if (!$single || !$single->hasTranslation($langcode)) {
+            return null;
+        }
+
+        return $single->getTranslation($langcode);
     }
 }

--- a/wmsingles.services.yml
+++ b/wmsingles.services.yml
@@ -1,7 +1,7 @@
 services:
   wmsingles:
     class: Drupal\wmsingles\Service\WmSingles
-    arguments: ['@entity_type.manager', '@state']
+    arguments: ['@entity_type.manager', '@state', '@language_manager']
 
   # Event subscribers.
   wmsingles.nodetypeform_subscriber:


### PR DESCRIPTION
`::getSingleByBundle()` and `::getSingle()` should return the translation based on the current interface language.