### PR TITLE
Fix faulty access checking for default node types

### DIFF
--- a/src/Access/SingleNodeAccessControlHandler.php
+++ b/src/Access/SingleNodeAccessControlHandler.php
@@ -38,9 +38,7 @@ class SingleNodeAccessControlHandler extends NodeAccessControlHandler
             return $return_as_object ? $result : $result->isAllowed();
         }
 
-        $result = parent::access($entity, $operation, $account, true);
-
-        return $return_as_object ? $result : $result->isAllowed();
+        return parent::access($entity, $operation, $account, true);
     }
 
     public function createAccess($entity_bundle = null, ?AccountInterface $account = null, array $context = [], $return_as_object = false)
@@ -55,8 +53,6 @@ class SingleNodeAccessControlHandler extends NodeAccessControlHandler
             return $return_as_object ? $result : $result->isAllowed();
         }
 
-        $result = parent::createAccess($entity_bundle, $account, $context, $return_as_object);
-
-        return $return_as_object ? $result : $result->isAllowed();
+        return parent::createAccess($entity_bundle, $account, $context, $return_as_object);
     }
 }


### PR DESCRIPTION
## Description
The parent already performs the return as object check so no need to do it again.

<!-- Write a brief description of the changes introduced by this PR -->

### Documentation
/
<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
-->

## Related Issues
/
<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
